### PR TITLE
감정 calm 출력, 초대코드 알림창 등 수정

### DIFF
--- a/app/src/main/java/com/example/harumub_front/ResultActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/ResultActivity.kt
@@ -239,23 +239,29 @@ class ResultActivity : AppCompatActivity() {
                     val top3 = Array(7, {" "})
                     var m = 0
                     mapSorted.forEach { (key, value) ->
-                        // println("key: "+ key)
-                        top3[m] = key
-                        m += 1
+                        // println("key: "+ key + ", value: "+ value)
+                        if(value != 0) {
+                            top3[m] = key
+                            m += 1
+                        }
                     }
                     for(i in 0..2) {
                         for (j in 0..6) {
                             if (i == 0) {
                                 if(top3[i] == emotionIndex[j]) emotion1.setImageResource(emoji[j])
+                                else if(top3[i] == " ") emotion1.setImageResource(emoji[7]) // value=0: calm
                             }
                             else if (i == 1) {
                                 if(top3[i] == emotionIndex[j]) emotion2.setImageResource(emoji[j])
+                                else if(top3[i] == " ") emotion2.setImageResource(emoji[7]) // value=0: calm
                             }
                             else if (i == 2) {
                                 if(top3[i] == emotionIndex[j]) emotion3.setImageResource(emoji[j])
+                                else if(top3[i] == " ") emotion3.setImageResource(emoji[7]) // value=0: calm
                             }
                         }
                     }
+
 
                     // 감정 그래프 출력
                     val chart = ArrayList<Entry>() // 감정 차트 배열 > 새 데이터 좌표값 추가 가능

--- a/app/src/main/java/com/example/harumub_front/SignupActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/SignupActivity.kt
@@ -257,7 +257,7 @@ class SignupActivity : AppCompatActivity() {
                             //btnAuth.setEnabled(true)
                             emailCode = true
 
-                            //Toast.makeText(this@SignupActivity, "email send successfully", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this@SignupActivity, "email send successfully", Toast.LENGTH_SHORT).show()
                         }
                         else if (response.code() == 400){
                             Toast.makeText(this@SignupActivity, "email send error", Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/layout/dialog_entercode_copy.xml
+++ b/app/src/main/res/layout/dialog_entercode_copy.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal"
+    android:background="#264713">
+
+    <TextView
+        android:layout_marginTop="10dp"
+        android:padding="10dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="초대 코드 발급"
+        android:fontFamily="@font/jua"
+        android:textSize="28dp"
+        android:textColor="#FFFFFF"/>
+
+    <TextView
+        android:padding="10dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="확인 버튼 클릭시 초대코드가 자동으로 복사됩니다."
+        android:fontFamily="@font/jua"
+        android:textSize="17sp"
+        android:textColor="#EEEEEE" />
+
+    <TextView
+        android:id="@+id/myEnterCode"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:background="@drawable/edittext_round"
+        android:padding="15dp"
+        android:text="My Entercode"
+        android:textSize="20sp"
+        android:fontFamily="@font/jua"
+        android:textColor="#264713" />
+
+</LinearLayout>


### PR DESCRIPTION
- 결과 페이지: 감정 값 0일 때 calm 이미지 출력
- 입장 페이지: 초대코드 발급시 알림창 다이얼로그 띄우기
- 회원가입 페이지: 이메일 인증 코드 토스트 메세지 주석처리 및 성공 메세지 설정
- 검색 어댑터: 포스터 기본 이미지 설정