### PR TITLE
추천 데이터 메인 페이지와 모든 페이지에 연결

### DIFF
--- a/app/src/main/java/com/example/harumub_front/AddreviewActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/AddreviewActivity.kt
@@ -73,6 +73,16 @@ class AddreviewActivity : AppCompatActivity() {
     lateinit var reco3_titleArray : java.util.ArrayList<String>
     lateinit var reco3_posterArray : java.util.ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.fragment_addreview)
@@ -107,6 +117,16 @@ class AddreviewActivity : AppCompatActivity() {
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as ArrayList<String>
 
         // 혼자보기 페이지에서 전달받은 인텐트 데이터 확인
         if (intent.hasExtra("user_id") && intent.hasExtra("movie_title")) {
@@ -226,6 +246,16 @@ class AddreviewActivity : AppCompatActivity() {
 
                             intent.putExtra("reco3_titleArray", reco3_titleArray)
                             intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                            intent.putExtra("reco4_year", reco4_year)
+                            intent.putExtra("reco4_titleArray", reco4_titleArray)
+                            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                            intent.putExtra("reco5_titleArray", reco5_titleArray)
+                            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                            intent.putExtra("reco6_titleArray", reco6_titleArray)
+                            intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                             startActivityForResult(intent, 0)
                         }

--- a/app/src/main/java/com/example/harumub_front/MainActivity2.kt
+++ b/app/src/main/java/com/example/harumub_front/MainActivity2.kt
@@ -256,7 +256,9 @@ class MainActivity2 : AppCompatActivity(), NavigationView.OnNavigationItemSelect
         recyclerView2.layoutManager = layoutManager2
 //        adapter2 = RecommendAdapter2(reco2_userIdList, reco2_titleList, reco2_posterList)
         adapter2 = RecommendAdapter2(id, reco2_userIdList, reco2_titleList, reco2_posterList,
-            reco1_titleArray, reco1_posterArray, reco3_titleArray, reco3_posterArray)
+            reco1_titleArray, reco1_posterArray, reco3_titleArray, reco3_posterArray,
+            reco4_year, reco4_titleArray, reco4_posterArray, reco5_titleArray, reco5_posterArray,
+            reco6_titleArray, reco6_posterArray)
         recyclerView2.adapter = adapter2
 
         // '당신이 선호하는' 영화 목록 RecyclerView와 RecommendAdapter3 연결

--- a/app/src/main/java/com/example/harumub_front/RecommendAdapter2.kt
+++ b/app/src/main/java/com/example/harumub_front/RecommendAdapter2.kt
@@ -19,7 +19,10 @@ import java.net.URL
 
 class RecommendAdapter2(var id: String, var userIdList: ArrayList<String>, var titlesList: ArrayList<ArrayList<String>>, var postersList: ArrayList<ArrayList<String>>,
                         var reco1_titleArray: ArrayList<String>, var reco1_posterArray: ArrayList<String>,
-                        var reco3_titleArray: ArrayList<String>, var reco3_posterArray: ArrayList<String>):
+                        var reco3_titleArray: ArrayList<String>, var reco3_posterArray: ArrayList<String>,
+                        var reco4_year: String, var reco4_titleArray: ArrayList<String>, var reco4_posterArray: ArrayList<String>,
+                        var reco5_titleArray: ArrayList<String>, var reco5_posterArray: ArrayList<String>,
+                        var reco6_titleArray: ArrayList<String>, var reco6_posterArray: ArrayList<String>):
     RecyclerView.Adapter<RecommendAdapter2.ViewHolder>() {
 
     lateinit var reco2_userId : String
@@ -95,6 +98,16 @@ class RecommendAdapter2(var id: String, var userIdList: ArrayList<String>, var t
 
                 intent.putExtra("reco3_titleArray", reco3_titleArray)
                 intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                intent.putExtra("reco4_year", reco4_year)
+                intent.putExtra("reco4_titleArray", reco4_titleArray)
+                intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                intent.putExtra("reco5_titleArray", reco5_titleArray)
+                intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                intent.putExtra("reco6_titleArray", reco6_titleArray)
+                intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                 itemView.context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
             }

--- a/app/src/main/java/com/example/harumub_front/ResultActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/ResultActivity.kt
@@ -74,6 +74,16 @@ class ResultActivity : AppCompatActivity() {
     lateinit var reco3_titleArray : ArrayList<String>
     lateinit var reco3_posterArray : ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     private lateinit var myHighlight: ImageView
 
     lateinit var photoFile: File
@@ -114,6 +124,16 @@ class ResultActivity : AppCompatActivity() {
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as ArrayList<String>
 
         // 리뷰 페이지에서 전달받은 인텐트 데이터 확인
         if (intent.hasExtra("user_id") && intent.hasExtra("movie_title")) {
@@ -348,12 +368,14 @@ class ResultActivity : AppCompatActivity() {
                 //Toast.makeText(this@ResultActivity, t.message, Toast.LENGTH_LONG).show()
             }
         })
+
         // 메인으로 돌아가는 버튼
         btnMain.setOnClickListener {
             var intent = Intent(
                 applicationContext,
                 MainActivity2::class.java
             ) // 두번째 인자에 이동할 액티비티
+
             intent.putExtra("user_id", id)
 
             intent.putExtra("reco1_titleArray", reco1_titleArray)
@@ -379,6 +401,16 @@ class ResultActivity : AppCompatActivity() {
 
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
 
             startActivityForResult(intent, 0)
         }
@@ -414,6 +446,16 @@ class ResultActivity : AppCompatActivity() {
 
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
 
             startActivityForResult(intent, 0)
         }

--- a/app/src/main/java/com/example/harumub_front/SearchActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/SearchActivity.kt
@@ -59,6 +59,16 @@ class SearchActivity : AppCompatActivity() , TextWatcher {
     lateinit var reco3_titleArray : java.util.ArrayList<String>
     lateinit var reco3_posterArray : java.util.ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     var movieList = ArrayList<MovieModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -93,6 +103,16 @@ class SearchActivity : AppCompatActivity() , TextWatcher {
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as java.util.ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as java.util.ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as ArrayList<String>
 
         // 메인 페이지에서 전달받은 인텐트 데이터 확인
         if (intent.hasExtra("user_id")) {
@@ -146,7 +166,8 @@ class SearchActivity : AppCompatActivity() , TextWatcher {
                         reco1_titleArray, reco1_posterArray, reco2_1_userId, reco2_2_userId, reco2_3_userId, reco2_4_userId, reco2_5_userId,
                         reco2_1_title, reco2_2_title, reco2_3_title, reco2_4_title, reco2_5_title,
                         reco2_1_poster, reco2_2_poster, reco2_3_poster, reco2_4_poster, reco2_5_poster,
-                        reco3_titleArray, reco3_posterArray)
+                        reco3_titleArray, reco3_posterArray, reco4_year, reco4_titleArray, reco4_posterArray,
+                        reco5_titleArray, reco5_posterArray, reco6_titleArray, reco6_posterArray)
                     recyclerView!!.layoutManager =
                         LinearLayoutManager(applicationContext, LinearLayoutManager.VERTICAL, false)
                     recyclerView!!.adapter = adapter

--- a/app/src/main/java/com/example/harumub_front/SearchAdapter.kt
+++ b/app/src/main/java/com/example/harumub_front/SearchAdapter.kt
@@ -25,7 +25,10 @@ class SearchAdapter(var context: Context, var id: String, var movieList: ArrayLi
                     var reco2_4_title : ArrayList<String>, var reco2_5_title : ArrayList<String>,
                     var reco2_1_poster : ArrayList<String>, var reco2_2_poster : ArrayList<String>, var reco2_3_poster : ArrayList<String>,
                     var reco2_4_poster : ArrayList<String>, var reco2_5_poster : ArrayList<String>,
-                    var reco3_titleArray : ArrayList<String>, var reco3_posterArray : ArrayList<String>) :
+                    var reco3_titleArray : ArrayList<String>, var reco3_posterArray : ArrayList<String>,
+                    var reco4_year : String, var reco4_titleArray : ArrayList<String>, var reco4_posterArray : ArrayList<String>,
+                    var reco5_titleArray : ArrayList<String>, var reco5_posterArray : ArrayList<String>,
+                    var reco6_titleArray : ArrayList<String>, var reco6_posterArray : ArrayList<String>) :
     RecyclerView.Adapter<SearchAdapter.MyViewHolder>(), Filterable {
 
     var filteredMovieList = ArrayList<MovieModel>()
@@ -124,6 +127,16 @@ class SearchAdapter(var context: Context, var id: String, var movieList: ArrayLi
 
                 intent.putExtra("reco3_titleArray", reco3_titleArray)
                 intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                intent.putExtra("reco4_year", reco4_year)
+                intent.putExtra("reco4_titleArray", reco4_titleArray)
+                intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                intent.putExtra("reco5_titleArray", reco5_titleArray)
+                intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                intent.putExtra("reco6_titleArray", reco6_titleArray)
+                intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                 itemView.context.startActivity(intent.addFlags(FLAG_ACTIVITY_NEW_TASK));
             }

--- a/app/src/main/java/com/example/harumub_front/UserMovieListActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/UserMovieListActivity.kt
@@ -61,6 +61,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
     lateinit var reco3_titleArray : java.util.ArrayList<String>
     lateinit var reco3_posterArray : java.util.ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     private lateinit var retrofitBuilder: RetrofitBuilder
     private lateinit var retrofitInterface : RetrofitInteface
 
@@ -106,6 +116,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as java.util.ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as java.util.ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as ArrayList<String>
 
         retrofitBuilder = RetrofitBuilder
         retrofitInterface = retrofitBuilder.api
@@ -187,6 +207,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
+
             startActivity(intent)
         }
 
@@ -224,6 +254,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
 
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
 
             startActivity(intent)
         }
@@ -263,6 +303,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }
@@ -298,6 +348,16 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }
@@ -327,6 +387,17 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
                     intent.putExtra("reco2_5_poster", reco2_5_poster)
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }

--- a/app/src/main/java/com/example/harumub_front/WatchAloneActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/WatchAloneActivity.kt
@@ -84,6 +84,16 @@ class WatchAloneActivity : AppCompatActivity() {
     lateinit var reco3_titleArray : ArrayList<String>
     lateinit var reco3_posterArray : ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     var map_Capture = HashMap<String, String>()
     var call_Capture  = retrofitInterface.executeWatchImageCaptureEyetrack(map_Capture)
 
@@ -118,6 +128,16 @@ class WatchAloneActivity : AppCompatActivity() {
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as ArrayList<String>
 
         // 검색 페이지에서 전달받은 인텐트 데이터 확인
         if (intent.hasExtra("user_id") && intent.hasExtra("movie_title")) {
@@ -256,6 +276,16 @@ class WatchAloneActivity : AppCompatActivity() {
 
                         intent.putExtra("reco3_titleArray", reco3_titleArray)
                         intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                        intent.putExtra("reco4_year", reco4_year)
+                        intent.putExtra("reco4_titleArray", reco4_titleArray)
+                        intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                        intent.putExtra("reco5_titleArray", reco5_titleArray)
+                        intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                        intent.putExtra("reco6_titleArray", reco6_titleArray)
+                        intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                         startActivity(intent)
 
@@ -397,6 +427,16 @@ class WatchAloneActivity : AppCompatActivity() {
                                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                                     intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+                                    intent.putExtra("reco4_year", reco4_year)
+                                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                                     startActivity(intent)
 
                                     Log.d("WatchAloneEnd : ", "감상 리뷰 작성 페이지로 이동")
@@ -470,6 +510,16 @@ class WatchAloneActivity : AppCompatActivity() {
 
                                 intent.putExtra("reco3_titleArray", reco3_titleArray)
                                 intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                                intent.putExtra("reco4_year", reco4_year)
+                                intent.putExtra("reco4_titleArray", reco4_titleArray)
+                                intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                                intent.putExtra("reco5_titleArray", reco5_titleArray)
+                                intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                                intent.putExtra("reco6_titleArray", reco6_titleArray)
+                                intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                                 startActivity(intent)
 

--- a/app/src/main/java/com/example/harumub_front/WatchListActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/WatchListActivity.kt
@@ -61,6 +61,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
     lateinit var reco3_titleArray : ArrayList<String>
     lateinit var reco3_posterArray : ArrayList<String>
 
+    lateinit var reco4_year : String
+    lateinit var reco4_titleArray : ArrayList<String>
+    lateinit var reco4_posterArray : ArrayList<String>
+
+    lateinit var reco5_titleArray : ArrayList<String>
+    lateinit var reco5_posterArray : ArrayList<String>
+
+    lateinit var reco6_titleArray : ArrayList<String>
+    lateinit var reco6_posterArray : ArrayList<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_my_movie_list)
@@ -91,6 +101,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
 
         reco3_titleArray = intent.getSerializableExtra("reco3_titleArray") as ArrayList<String>
         reco3_posterArray = intent.getSerializableExtra("reco3_posterArray") as ArrayList<String>
+
+        reco4_year = intent.getStringExtra("reco4_year").toString()
+        reco4_titleArray = intent.getSerializableExtra("reco4_titleArray") as java.util.ArrayList<String>
+        reco4_posterArray = intent.getSerializableExtra("reco4_posterArray") as java.util.ArrayList<String>
+
+        reco5_titleArray = intent.getSerializableExtra("reco5_titleArray") as java.util.ArrayList<String>
+        reco5_posterArray = intent.getSerializableExtra("reco5_posterArray") as java.util.ArrayList<String>
+
+        reco6_titleArray = intent.getSerializableExtra("reco6_titleArray") as java.util.ArrayList<String>
+        reco6_posterArray = intent.getSerializableExtra("reco6_posterArray") as java.util.ArrayList<String>
 
         // 메인 페이지에서 전달받은 인텐트 데이터 확인
         if (intent.hasExtra("user_id")) {
@@ -159,7 +179,8 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                         reco2_1_userId, reco2_2_userId, reco2_3_userId, reco2_4_userId, reco2_5_userId,
                         reco2_1_title, reco2_2_title, reco2_3_title, reco2_4_title, reco2_5_title,
                         reco2_1_poster, reco2_2_poster, reco2_3_poster, reco2_4_poster, reco2_5_poster,
-                        reco3_titleArray, reco3_posterArray)
+                        reco3_titleArray, reco3_posterArray, reco4_year, reco4_titleArray, reco4_posterArray,
+                        reco5_titleArray, reco5_posterArray, reco6_titleArray, reco6_posterArray)
                     recyclerView.adapter = adapter
 
                     //Toast.makeText(this@WatchListActivity, "get movie list successfully", Toast.LENGTH_SHORT).show()
@@ -216,6 +237,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
+
             startActivity(intent)
         }
 
@@ -256,6 +287,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
             intent.putExtra("reco3_titleArray", reco3_titleArray)
             intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+            intent.putExtra("reco4_year", reco4_year)
+            intent.putExtra("reco4_titleArray", reco4_titleArray)
+            intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+            intent.putExtra("reco5_titleArray", reco5_titleArray)
+            intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+            intent.putExtra("reco6_titleArray", reco6_titleArray)
+            intent.putExtra("reco6_posterArray", reco6_posterArray)
+
             startActivity(intent)
         }
     }
@@ -294,6 +335,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }
@@ -329,6 +380,16 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
 
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }
@@ -358,6 +419,17 @@ class WatchListActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
                     intent.putExtra("reco2_5_poster", reco2_5_poster)
                     intent.putExtra("reco3_titleArray", reco3_titleArray)
                     intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                    intent.putExtra("reco4_year", reco4_year)
+                    intent.putExtra("reco4_titleArray", reco4_titleArray)
+                    intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                    intent.putExtra("reco5_titleArray", reco5_titleArray)
+                    intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                    intent.putExtra("reco6_titleArray", reco6_titleArray)
+                    intent.putExtra("reco6_posterArray", reco6_posterArray)
+
                     startActivityForResult(intent, 0) // + 결과값 전달 // requestCode: 액티비티 식별값 - 원하는 값
                     commit()
                 }

--- a/app/src/main/java/com/example/harumub_front/WatchListAdapter.kt
+++ b/app/src/main/java/com/example/harumub_front/WatchListAdapter.kt
@@ -22,7 +22,10 @@ class WatchListAdapter(var id: String, var titles: ArrayList<String>, var poster
                        var reco2_4_title : ArrayList<String>, var reco2_5_title : ArrayList<String>,
                        var reco2_1_poster : ArrayList<String>, var reco2_2_poster : ArrayList<String>, var reco2_3_poster : ArrayList<String>,
                        var reco2_4_poster : ArrayList<String>, var reco2_5_poster : ArrayList<String>,
-                       var reco3_titleArray : ArrayList<String>, var reco3_posterArray : ArrayList<String>):
+                       var reco3_titleArray : ArrayList<String>, var reco3_posterArray : ArrayList<String>,
+                       var reco4_year : String, var reco4_titleArray : ArrayList<String>, var reco4_posterArray : ArrayList<String>,
+                       var reco5_titleArray : ArrayList<String>, var reco5_posterArray : ArrayList<String>,
+                       var reco6_titleArray : ArrayList<String>, var reco6_posterArray : ArrayList<String>):
     RecyclerView.Adapter<WatchListAdapter.ViewHolder>() {
 
     var defaultImage = R.drawable.default_poster
@@ -103,6 +106,16 @@ class WatchListAdapter(var id: String, var titles: ArrayList<String>, var poster
 
                 intent.putExtra("reco3_titleArray", reco3_titleArray)
                 intent.putExtra("reco3_posterArray", reco3_posterArray)
+
+                intent.putExtra("reco4_year", reco4_year)
+                intent.putExtra("reco4_titleArray", reco4_titleArray)
+                intent.putExtra("reco4_posterArray", reco4_posterArray)
+
+                intent.putExtra("reco5_titleArray", reco5_titleArray)
+                intent.putExtra("reco5_posterArray", reco5_posterArray)
+
+                intent.putExtra("reco6_titleArray", reco6_titleArray)
+                intent.putExtra("reco6_posterArray", reco6_posterArray)
 
                 itemView.context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
             }


### PR DESCRIPTION
- AddreviewActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- MainActivity2
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- RecommendAdapter2
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- ResultActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- SearchActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- SearchAdapter
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- UserMovieListActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- WatchAloneActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- WatchListActivity
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

- WatchListAdapter
  - 추천 데이터 메인 페이지와 모든 페이지에 연결되도록 수정

