### PR TITLE
로그아웃 시 전의 페이지 스택 삭제 & 메인 페이지에서 뒤로 가기 막기 & 같이보기 종료 시 액티비티 종료

### DIFF
--- a/app/src/main/java/com/example/harumub_front/EnterActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/EnterActivity.kt
@@ -175,6 +175,8 @@ class EnterActivity: BaseActivity(), NavigationView.OnNavigationItemSelectedList
                     message.text = result!!.roomCode
                     dig.setView(dialogView)
 
+                    val adig = dig.create()
+
                     cancelBtn = dialogView.findViewById<Button>(R.id.cancelBtn)
                     checkBtn = dialogView.findViewById<Button>(R.id.checkBtn)
 
@@ -230,13 +232,17 @@ class EnterActivity: BaseActivity(), NavigationView.OnNavigationItemSelectedList
                         intent.putExtra("reco6_posterArray", reco6_posterArray)
                         startActivity(intent)
 
+                        adig.dismiss()
+
                         Log.w("EnterActivity", "다이얼로그 확인 버튼 클릭 > 방 입장")
                         //Toast.makeText(this@EnterActivity, "방 코드 [" + result.roomCode + "]에 HOST로 입장합니다.", Toast.LENGTH_SHORT).show()
                     }
+
                     cancelBtn.setOnClickListener {
                         //Toast.makeText(this, "취소되었습니다.", Toast.LENGTH_LONG).show()
                     }
-                    dig.show()
+                    
+                    adig.show()
                 } else if (response.code() == 400) {
                     Log.e("EnterActivity", "방 생성 중 오류 발생")
                     //Toast.makeText(this@EnterActivity, "방 생성 중 오류 발생", Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/example/harumub_front/EnterActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/EnterActivity.kt
@@ -546,6 +546,7 @@ class EnterActivity: BaseActivity(), NavigationView.OnNavigationItemSelectedList
                         override fun onResponse(call: Call<Void?>, response: Response<Void?>) {
                             if (response.code() == 200) {
                                 val intent = Intent(applicationContext, LoginActivity::class.java) // 두번째 인자에 이동할 액티비티
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
 
                                 Toast.makeText(this@EnterActivity, "로그아웃합니다..", Toast.LENGTH_LONG).show()
                                 startActivity(intent)

--- a/app/src/main/java/com/example/harumub_front/MainActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.example.harumub_front
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
@@ -9,6 +8,7 @@ import android.widget.Button
 import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -18,7 +18,6 @@ import kotlinx.android.synthetic.main.activity_main.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.util.HashMap
 
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
     private lateinit var retrofitBuilder: RetrofitBuilder
@@ -512,6 +511,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
                         override fun onResponse(call: Call<Void?>, response: Response<Void?>) {
                             if (response.code() == 200) {
                                 val intent = Intent(applicationContext, LoginActivity::class.java) // 두번째 인자에 이동할 액티비티
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
 
                                 Toast.makeText(this@MainActivity, "로그아웃합니다..", Toast.LENGTH_LONG).show()
                                 startActivity(intent)

--- a/app/src/main/java/com/example/harumub_front/MainActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/MainActivity.kt
@@ -528,4 +528,8 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         main_this.closeDrawers() // 네비게이션 뷰 닫기
         return false
     }
+
+    override fun onBackPressed() { // 뒤로 가기 버튼 막기
+        //super.onBackPressed()
+    }
 }

--- a/app/src/main/java/com/example/harumub_front/ResultActivity_ticket_front.kt
+++ b/app/src/main/java/com/example/harumub_front/ResultActivity_ticket_front.kt
@@ -364,6 +364,4 @@ class ResultActivity_ticket_front : AppCompatActivity() {
             }.start()
         }
     }
-
-
 }

--- a/app/src/main/java/com/example/harumub_front/TogetherActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/TogetherActivity.kt
@@ -629,6 +629,7 @@ class TogetherActivity : BaseActivity(), DuringCallEventHandler {
                     Log.w("TogetherActivity", "Room & Room Code 삭제")
 
                     // 입장 페이지로 다시 돌아가기
+/*
                     val intent = Intent(applicationContext, EnterActivity::class.java)
                     intent.putExtra("user_id", id)
                     intent.putExtra("reco1_titleArray", reco1_titleArray)
@@ -657,6 +658,8 @@ class TogetherActivity : BaseActivity(), DuringCallEventHandler {
                     intent.putExtra("reco6_posterArray", reco6_posterArray)
                     intent.putExtra("hasJoined", true)
                     startActivity(intent)   // startActivityForResult(intent, 1)
+*/
+                    finish()
                 }
                 else if (response.code() == 400) {
                     Log.w("TogetherActivity", "방 삭제 중 오류 발생")

--- a/app/src/main/java/com/example/harumub_front/UserMovieListActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/UserMovieListActivity.kt
@@ -134,6 +134,7 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
         drawer_button.setOnClickListener{
             main_this.openDrawer(GravityCompat.START) // START = left, END : right (드로어가 나오는 방향지정)
         }
+
         // 네비게이션 메뉴 아이템에 클릭 속성 부여
         drawer_view.setNavigationItemSelectedListener(this)
 
@@ -364,6 +365,7 @@ class UserMovieListActivity : AppCompatActivity(), NavigationView.OnNavigationIt
                         override fun onResponse(call: Call<Void?>, response: Response<Void?>) {
                             if (response.code() == 200) {
                                 var intent = Intent(applicationContext, LoginActivity::class.java) // 두번째 인자에 이동할 액티비티
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
 
                                 Toast.makeText(this@UserMovieListActivity, "로그아웃합니다..", Toast.LENGTH_LONG).show()
                                 startActivity(intent)

--- a/app/src/main/java/com/example/harumub_front/WatchListActivity.kt
+++ b/app/src/main/java/com/example/harumub_front/WatchListActivity.kt
@@ -390,6 +390,7 @@ class WatchListActivity : AppCompatActivity()
                         override fun onResponse(call: Call<Void?>, response: Response<Void?>) {
                             if (response.code() == 200) {
                                 var intent = Intent(applicationContext, LoginActivity::class.java) // 두번째 인자에 이동할 액티비티
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
 
                                 Toast.makeText(this@WatchListActivity, "로그아웃합니다..", Toast.LENGTH_LONG).show()
                                 startActivity(intent)


### PR DESCRIPTION
- EnterActivity
  - 로그아웃 시 전의 페이지 스택 삭제
  - '새로운 방 생성' 버튼 클릭 시 나타나는 다이얼로그의 '확인' 버튼 클릭 시 다이얼로그 닫기

- MainActivity
  - 로그아웃 시 전의 페이지 스택 삭제
  - 메인 페이지에서 뒤로 가기 막기

- ResultActivity_ticket_front
  - 공백 삭제

- TogetherActivity
  - 같이보기 종료 시 액티비티 종료

- UserMovieListActivity
  - 로그아웃 시 전의 페이지 스택 삭제

- WatchListActivity
  - 로그아웃 시 전의 페이지 스택 삭제 - 현재 드로어 메뉴 주석 처리되어 있다.
